### PR TITLE
Fixed the incorrect exports and types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "4.0.0",
   "description": "Helper utilities for using @notion/client",
   "type": "module",
-  "exports": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "dependencies": {
     "typescript": "^5.0.0"
   },


### PR DESCRIPTION
Fixes #335

From what I can see, these entries should always start with `./` as explained [here](https://webpack.js.org/guides/package-exports/)