### PR TITLE
skip-changelogラベルの自動付与とリリースノート除外設定を追加

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+# ライブラリの挙動に関係ないファイルのみの変更時にラベルを付与する
+# 否定パターンで「全ファイルがライブラリ関連でない」を表現
+skip-changelog:
+  - changed-files:
+      - all-globs-to-all-files:
+          - '!src/**'
+          - '!package.json'
+          - '!package-lock.json'
+          - '!tsconfig.json'
+          - '!tsconfig.publish.json'
+          - '!biome.json'
+          - '!vitest.config.ts'
+          - '!.gitignore'
+          - '!.npmignore'
+          - '!LICENSE.txt'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,7 @@
 changelog:
+  exclude:
+    labels:
+      - skip-changelog
   categories:
     - title: Breaking Changes
       labels:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1


### PR DESCRIPTION
## 概要

- リリースノートの自動生成から `skip-changelog` ラベル付きPRを除外する設定を追加
- `actions/labeler` を使い、ライブラリの挙動に関係ないファイルのみが変更されたPRに `skip-changelog` ラベルを自動付与するワークフローを追加

## 変更内容

- `.github/release.yml`: `skip-changelog` ラベルのexclude設定を追加
- `.github/labeler.yml`: ラベル付与ルールを定義（`all-globs-to-all-files` で全変更ファイルが非ライブラリファイルの場合のみマッチ）
- `.github/workflows/labeler.yml`: PR作成・更新時にlabelerを実行するワークフロー

## 対象ファイル（skip-changelog対象）

- `.github/**`, `.claude/**`, `.husky/**`
- `CLAUDE.md`, `README.md`, `CHANGELOG.md`
- `.tagpr`, `renovate.json`, `.node-version`

## テストプラン

- [ ] ライブラリ関連ファイルのみ変更したPRにラベルが付かないことを確認
- [ ] 非ライブラリファイルのみ変更したPRにskip-changelogラベルが付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)