### PR TITLE
ci: switch npm publish to staged publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,11 +22,14 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: npm
 
+      - name: Ensure npm CLI supports staged publishing
+        run: npm install -g npm@">=11.15.0"
+
       - name: Installing dependencies
         run: npm ci --no-fund --no-audit
 
       - name: Build package
         run: npm run build:publish
 
-      - name: Publishing to npm
-        run: npm publish --access public --provenance
+      - name: Publishing to npm (staged)
+        run: npm stage publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: npm
 
-      - name: Ensure npm CLI supports staged publishing
-        run: npm install -g npm@">=11.15.0"
+      - name: Activate npm version pinned in package.json
+        run: |
+          corepack enable
+          corepack prepare --activate
 
       - name: Installing dependencies
         run: npm ci --no-fund --no-audit

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.5",
   "description": "Helper utilities for using @notion/client",
   "type": "module",
+  "packageManager": "npm@11.15.0",
   "exports": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Use the new `npm stage publish` command (npm CLI 11.15.0+) so that
each release goes through the staging queue and requires explicit
maintainer approval with 2FA before becoming installable from the
registry. The existing OIDC trusted-publishing setup (id-token: write,
environment: publish) continues to work since trusted publishing
supports both `npm publish` and `npm stage publish`.