### PR TITLE
Fix corepack enable command to specify npm version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Activate npm version pinned in package.json
         run: |
-          corepack enable
+          corepack enable npm
           corepack prepare --activate
 
       - name: Installing dependencies


### PR DESCRIPTION
## Summary
Updated the GitHub Actions publish workflow to explicitly specify `npm` when enabling corepack, ensuring the correct package manager version is activated as pinned in package.json.

## Changes
- Modified `.github/workflows/publish.yml` to change `corepack enable` to `corepack enable npm`
  - This ensures corepack activates the npm version specified in package.json before running `corepack prepare --activate`
  - Prevents potential issues with corepack selecting an incorrect package manager version

## Details
The change is a minor but important fix to the CI/CD pipeline that ensures the npm version pinned in package.json (as per the project's Node 22.20.0 setup) is properly activated during the publish workflow.

https://claude.ai/code/session_01KpFsabJkaMvdojBaXMVYXN