### PR TITLE
chore: release v4.0.6 with workflow improvements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 jobs:
   release:
@@ -24,8 +25,9 @@ jobs:
 
       - name: Activate npm version pinned in package.json
         run: |
-          corepack enable npm
-          corepack prepare --activate
+          corepack enable
+          corepack install
+          echo "Active npm version: $(npm --version)"
 
       - name: Installing dependencies
         run: npm ci --no-fund --no-audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v4.0.6](https://github.com/sota1235/notion-sdk-js-helper/compare/v4.0.5...v4.0.6) - 2026-05-30
+### Dependencies
+- chore(deps): update dependency @biomejs/biome to v2.4.14 by @renovate[bot] in https://github.com/sota1235/notion-sdk-js-helper/pull/492
+- chore(deps): update dependency @biomejs/biome to v2.4.15 by @renovate[bot] in https://github.com/sota1235/notion-sdk-js-helper/pull/497
+- chore(deps): update vitest monorepo to v4.1.6 by @renovate[bot] in https://github.com/sota1235/notion-sdk-js-helper/pull/499
+- chore(deps): update dependency @types/node to v25.6.2 by @renovate[bot] in https://github.com/sota1235/notion-sdk-js-helper/pull/498
+- chore(deps): update dependency @types/node to v25.7.0 by @renovate[bot] in https://github.com/sota1235/notion-sdk-js-helper/pull/500
+- chore(deps): update dependency lint-staged to v17 by @renovate[bot] in https://github.com/sota1235/notion-sdk-js-helper/pull/495
+- chore(deps): update dependency @types/node to v25.9.1 by @renovate[bot] in https://github.com/sota1235/notion-sdk-js-helper/pull/501
+- chore(deps): update vitest monorepo to v4.1.7 by @renovate[bot] in https://github.com/sota1235/notion-sdk-js-helper/pull/503
+- chore(deps): update dependency @biomejs/biome to v2.4.16 by @renovate[bot] in https://github.com/sota1235/notion-sdk-js-helper/pull/504
+
 ## [v4.0.5](https://github.com/sota1235/notion-sdk-js-helper/compare/v4.0.4...v4.0.5) - 2026-05-01
 ### Dependencies
 - chore(deps): update dependency @types/node to v25.5.2 by @renovate[bot] in https://github.com/sota1235/notion-sdk-js-helper/pull/474

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sota1235/notion-sdk-js-helper",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Helper utilities for using @notion/client",
   "type": "module",
   "packageManager": "npm@11.15.0",


### PR DESCRIPTION
## Summary
Release version 4.0.6 with improvements to the publish workflow and dependency updates.

## Key Changes
- **Version bump**: Updated package version from 4.0.5 to 4.0.6
- **Workflow improvements**:
  - Added `workflow_dispatch` trigger to allow manual execution of the publish workflow
  - Simplified npm activation in CI: replaced `corepack prepare --activate` with `corepack install`
  - Added explicit npm version logging for better CI visibility
- **Changelog**: Added v4.0.6 release notes documenting dependency updates

## Implementation Details
The publish workflow now supports both automatic tag-based releases and manual triggering via GitHub Actions UI. The corepack commands were streamlined to use the more modern `corepack install` approach, which is more reliable for activating the npm version specified in package.json.

https://claude.ai/code/session_01NGpYKVhMFkQUefWew69Xne