### PR TITLE
ci(release): install pinned npm version for staged publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: npm
 
-      - name: Upgrade npm to the version pinned in package.json
+      - name: Install npm version pinned in package.json
         run: |
-          npm install -g "npm@$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]")"
-          echo "Active npm version: $(npm --version)"
+          PM=$(npm pkg get packageManager | tr -d '"')
+          npm install -g "${PM%%+*}"
+          npm --version
 
       - name: Installing dependencies
         run: npm ci --no-fund --no-audit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: npm
 
-      - name: Activate npm version pinned in package.json
+      - name: Upgrade npm to the version pinned in package.json
         run: |
-          corepack enable
-          corepack install
+          npm install -g "npm@$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]")"
           echo "Active npm version: $(npm --version)"
 
       - name: Installing dependencies


### PR DESCRIPTION
## 概要

`publish.yml` が npm のステージング公開（`npm stage publish`）に必要な npm バージョンを正しく有効化できておらず、リリースが失敗していた問題を修正します。

## 背景・原因

- `npm stage publish` は npm CLI **11.15.0+**（Node 22.14.0+）で導入された新コマンド。
- 現在の main の workflow は `corepack install` を使っているが、これは npm@11.15.0 を**キャッシュに入れるだけ**で PATH 上の `npm` を差し替えられず、setup-node 同梱の **11.13.0**（`stage` 非対応）が動作 → `Unknown command: "stage"` で失敗していた。

実際の失敗ログ:
```
corepack install → Adding npm@11.15.0 to the cache...
Active npm version: 11.13.0
```

## 変更内容

corepack 経由をやめ、`package.json` の `packageManager` フィールドの値を読んで npm を直接グローバルインストールするように変更:

```yaml
- name: Upgrade npm to the version pinned in package.json
  run: |
    npm install -g "npm@$(node -p "require('./package.json').packageManager.split('@')[1].split('+')[0]")"
    echo "Active npm version: $(npm --version)"
```

- npm 実体を確実に差し替えるため PATH 問題が起きない。
- バージョンは `packageManager` フィールドに単一ソース化（`.split('+')[0]` でハッシュ付き表記にも対応）。

## マージ後の手順

このPRをマージ後、Actions から `Publishing to npm` を **workflow_dispatch** で手動実行すると、main（package.json 4.0.6）から 4.0.6 をステージング公開できます。その後 `npm stage approve <stage-id>` で本公開してください。

https://claude.ai/code/session_01NGpYKVhMFkQUefWew69Xne

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGpYKVhMFkQUefWew69Xne)_