### PR TITLE
chore(renovate): exclude npm and devDependencies updates from changelog

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "extends": ["github>sota1235/renovate-config"],
   "labels": [
     "kind/dependencies"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["npm"],
+      "addLabels": ["skip-changelog"]
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "addLabels": ["skip-changelog"]
+    }
   ]
 }


### PR DESCRIPTION
Add skip-changelog label to npm (packageManager) and devDependencies
updates so they are excluded from the auto-generated changelog defined
in .github/release.yml.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014hmoyMG1DixM3vq2UdTMNC